### PR TITLE
Support Intel iwlwifi adapters with self-managed regulatory domains (AX200 tested)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,18 @@ seconds to leave managed Wi-Fi mode and bring up the pairing access point;
 wait for Barista to report that pairing is ready before using SYNC. It was
 stable once the pairing AP was running in our testing.
 
+Intel adapters (`iwlwifi`) work, but their driver **self-manages its regulatory
+domain**, which needs one extra thing from the environment: the firmware adopts
+a country only after hearing it from a neighboring 5 GHz access point during a
+scan, and falls back to the restrictive `00` world domain when nothing keeps
+supplying one. Barista scans to recover this automatically, so no manual setup
+is required, but a machine in true radio isolation has nothing to learn a
+country from and cannot host the pairing AP. `iw reg set` and
+`DRCD_REGULATORY_COUNTRY` cannot substitute — a self-managed domain ignores
+both. Tested with the **AX200** (desktop M.2, no ACPI regulatory tables, the
+harder case; laptops seed the country from firmware). Two `runtime-qos` tuning
+calls report `Operation not supported` on this driver and are skipped safely.
+
 For additional confirmed and incompatible hardware reports, see
 [Vanilla Wii U's Wireless Compatibility wiki](https://github.com/vanilla-wiiu/vanilla/wiki/Wireless-Compatibility).
 
@@ -106,6 +118,24 @@ the desktop locale and asks the user to confirm that it matches the machine's
 physical location. When confirmed, Barista can temporarily replace `00` for
 the session. It restores the previous domain at shutdown unless another
 component changed the setting in the meantime.
+
+If `iw reg get` marks the phy itself `(self-managed)` — Intel `iwlwifi` does —
+then the country override above cannot apply, because such a driver ignores the
+kernel regulatory core. Barista instead scans to make the firmware re-adopt a
+country, which requires a neighboring 5 GHz access point within range. There is
+no module option to disable this behavior; `iwlwifi.lar_disable` was removed
+from the kernel years ago and is silently ignored.
+
+Two host settings produce failures that look like Barista faults:
+
+- A radio soft-block reports `AP_START_FAILED` even though the adapter passes
+  every capability check. Check `rfkill list` and clear it with
+  `rfkill unblock wifi`.
+- A host firewall that denies inbound traffic lets the GamePad associate and
+  complete its key handshake, then stalls with protocol command timeouts and no
+  `dhcp: sent OFFER` line, because the GamePad's DHCP and protocol replies are
+  dropped locally. Allow inbound UDP on the GamePad interface for port 67 and
+  the runtime ports 50010 and 50020-50025.
 
 ## Build and install
 

--- a/core/drh/server/backend_linux.cpp
+++ b/core/drh/server/backend_linux.cpp
@@ -65,6 +65,9 @@ constexpr std::string_view kBroadcastIp = "192.168.1.255";
 constexpr uint16_t kSessionMtu = 1800;
 constexpr uint32_t kDhcpLeaseSeconds = 3600;
 constexpr std::string_view kTsfMonitorInterface = "drcdtsf";
+// A captured North American Wii U pairing AP selected channel 165. Cover every
+// non-DFS 5 GHz channel that hostapd can bring up immediately.
+constexpr std::array<int, 9> kPairingChannels{36, 40, 44, 48, 149, 153, 157, 161, 165};
 // Some USB adapters, notably rtw_8821au, report the PHY as busy briefly after
 // NetworkManager releases a managed connection.  Do not hand the interface to
 // hostapd until that transition has had time to complete.
@@ -246,9 +249,6 @@ std::vector<int> BuildPairingChannelPlan(int preferred_channel, bool sweep_enabl
 	if (!sweep_enabled)
 		return plan;
 
-	// A captured North American Wii U pairing AP selected channel 165. Cover
-	// every non-DFS 5 GHz channel that hostapd can bring up immediately.
-	constexpr std::array<int, 9> kPairingChannels{36, 40, 44, 48, 149, 153, 157, 161, 165};
 	for (const int channel : kPairingChannels)
 	{
 		if (std::find(plan.begin(), plan.end(), channel) == plan.end())
@@ -968,14 +968,73 @@ private:
 		return true;
 	}
 
+	// Self-managed-regulatory drivers (Intel iwlwifi/LAR hardware) ignore
+	// `iw reg set` entirely: they only adopt a real country after hearing a
+	// Country IE from a nearby AP, and they decay back to the restrictive "00"
+	// world-safe domain once nothing keeps feeding them one. NetworkManager's
+	// periodic scans normally do that, so releasing the interface for AP mode
+	// starts the decay. Drive our own scans and wait for a usable pairing
+	// channel to reappear.
+	bool RecoverRegulatoryByScan(const std::string& interface_name,
+		std::span<const int> pairing_channels, bool announce_ready, std::string& error)
+	{
+		constexpr auto kScanRecoveryTimeout = std::chrono::seconds(45);
+		constexpr auto kScanRecoveryPoll = std::chrono::milliseconds(1500);
+		constexpr auto kScanRecoveryRescan = std::chrono::seconds(6);
+
+		// Scanning requires the interface to be up; hostapd brings it down
+		// again itself when it needs to change mode.
+		const int fd = socket(AF_INET, SOCK_DGRAM | SOCK_CLOEXEC, 0);
+		if (fd >= 0)
+		{
+			ifreq up_flags{};
+			std::snprintf(up_flags.ifr_name, sizeof(up_flags.ifr_name), "%s", interface_name.c_str());
+			if (ioctl(fd, SIOCGIFFLAGS, &up_flags) == 0)
+			{
+				up_flags.ifr_flags = static_cast<short>(up_flags.ifr_flags | IFF_UP);
+				ioctl(fd, SIOCSIFFLAGS, &up_flags);
+			}
+			close(fd);
+		}
+
+		Log("regulatory: scanning to recover a usable 5 GHz pairing channel");
+		std::string scan_output;
+		RunIw({"dev", interface_name, "scan"}, scan_output);
+
+		const auto deadline = std::chrono::steady_clock::now() + kScanRecoveryTimeout;
+		auto next_rescan = std::chrono::steady_clock::now() + kScanRecoveryRescan;
+		while (std::chrono::steady_clock::now() < deadline)
+		{
+			if (is_stop_requested())
+			{
+				error = "operation cancelled";
+				return false;
+			}
+			if (CheckAdapterCompatibility(interface_name, pairing_channels, announce_ready, error))
+			{
+				Log("regulatory: scan recovered a usable 5 GHz pairing channel");
+				return true;
+			}
+			if (std::chrono::steady_clock::now() >= next_rescan)
+			{
+				std::string rescan_output;
+				RunIw({"dev", interface_name, "scan"}, rescan_output);
+				next_rescan = std::chrono::steady_clock::now() + kScanRecoveryRescan;
+			}
+			std::this_thread::sleep_for(kScanRecoveryPoll);
+		}
+		return false;
+	}
+
 	bool CheckAdapterWithRegulatoryRecovery(const std::string& interface_name,
 		std::span<const int> pairing_channels, bool announce_ready, std::string& error)
 	{
 		if (CheckAdapterCompatibility(interface_name, pairing_channels, announce_ready, error))
 			return true;
-		if (!CanApplyRegulatoryCountry(error) || !ApplyRegulatoryCountry(error))
-			return false;
-		return CheckAdapterCompatibility(interface_name, pairing_channels, announce_ready, error);
+		if (CanApplyRegulatoryCountry(error) && ApplyRegulatoryCountry(error) &&
+			CheckAdapterCompatibility(interface_name, pairing_channels, announce_ready, error))
+			return true;
+		return RecoverRegulatoryByScan(interface_name, pairing_channels, announce_ready, error);
 	}
 
 	void RestoreRegulatoryCountry()

--- a/third_party/hostapd-drc/patches/0014-ap-rescan-and-retry-when-channel-selection-hits-a-re.patch
+++ b/third_party/hostapd-drc/patches/0014-ap-rescan-and-retry-when-channel-selection-hits-a-re.patch
@@ -1,0 +1,118 @@
+From fe14fbaa88605d4ffc5886d4da99841ed735e676 Mon Sep 17 00:00:00 2001
+From: Barista build <build@barista.invalid>
+Date: Sat, 12 Sep 2026 20:24:19 -0400
+Subject: [PATCH] ap: rescan and retry when channel selection hits a reset
+ regdomain
+
+Intel iwlwifi LAR firmware reverts to the world-safe "00" regulatory
+domain when the interface changes mode, which happens while hostapd is
+initialising the AP. It only re-adopts a real country after hearing a
+Country IE during a scan, and hostapd reads its channel list before any
+scan occurs, so every 5 GHz channel appears unavailable and channel
+selection fails with "not found from the channel list of the current
+mode" even when the adapter was verified usable moments earlier.
+
+When resolving the configured channel or selecting the hardware mode
+fails, scan once to let the firmware re-adopt a country and retry. The
+scan is only reached after a failure, so adapters that do not
+self-manage their regulatory domain keep their existing code path and
+pay no startup delay.
+---
+ src/ap/hostapd.c | 62 ++++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 62 insertions(+)
+
+diff --git a/src/ap/hostapd.c b/src/ap/hostapd.c
+index a05de030d..2bc454026 100644
+--- a/src/ap/hostapd.c
++++ b/src/ap/hostapd.c
+@@ -2139,11 +2139,59 @@ static void hostapd_set_6ghz_sec_chan(struct hostapd_iface *iface)
+ }
+ 
+ 
++#ifdef CONFIG_TENDONIN
++/*
++ * Self-managed-regulatory drivers (Intel iwlwifi and its LAR firmware) fall
++ * back to the restrictive "00" world domain whenever the interface changes
++ * mode, which is exactly what happens while hostapd is bringing the interface
++ * up as an AP. The firmware only re-adopts a real country once it hears a
++ * Country IE from a nearby AP during a scan, and hostapd otherwise reads its
++ * channel list before any scan has happened - so every 5 GHz channel looks
++ * unavailable and channel selection fails with "not found from the channel
++ * list of the current mode".
++ *
++ * Kick off one scan and give the firmware a moment to apply the regulatory
++ * update, so the caller can re-read the channel list. This runs only after
++ * channel selection has already failed, which keeps it off the path entirely
++ * for drivers that do not self-manage their regulatory domain.
++ */
++static void hostapd_regulatory_prescan(struct hostapd_iface *iface)
++{
++	struct hostapd_data *hapd = iface->bss[0];
++	struct wpa_driver_scan_params params;
++	int i;
++
++	if (!hapd)
++		return;
++
++	os_memset(&params, 0, sizeof(params));
++	if (hostapd_driver_scan(hapd, &params) < 0) {
++		wpa_printf(MSG_DEBUG,
++			   "regulatory-prescan: could not start scan; continuing");
++		return;
++	}
++
++	/* The scan itself is asynchronous and its results are irrelevant here;
++	 * only the regulatory-domain side effect matters. */
++	for (i = 0; i < 60; i++)
++		os_sleep(0, 100000);
++	wpa_printf(MSG_DEBUG, "regulatory-prescan: done");
++}
++#endif /* CONFIG_TENDONIN */
++
++
+ static int setup_interface2(struct hostapd_iface *iface)
+ {
++#ifdef CONFIG_TENDONIN
++	int prescan_done = 0;
++#endif /* CONFIG_TENDONIN */
++
+ 	iface->wait_channel_update = 0;
+ 	iface->is_no_ir = false;
+ 
++#ifdef CONFIG_TENDONIN
++retry_after_prescan:
++#endif /* CONFIG_TENDONIN */
+ 	if (hostapd_get_hw_features(iface)) {
+ 		/* Not all drivers support this yet, so continue without hw
+ 		 * feature data. */
+@@ -2157,6 +2205,13 @@ static int setup_interface2(struct hostapd_iface *iface)
+ 		iface->is_ch_switch_dfs = false;
+ 
+ 		ret = configured_fixed_chan_to_freq(iface);
++#ifdef CONFIG_TENDONIN
++		if (ret < 0 && !prescan_done) {
++			prescan_done = 1;
++			hostapd_regulatory_prescan(iface);
++			goto retry_after_prescan;
++		}
++#endif /* CONFIG_TENDONIN */
+ 		if (ret < 0)
+ 			goto fail;
+ 
+@@ -2169,6 +2224,13 @@ static int setup_interface2(struct hostapd_iface *iface)
+ 		}
+ 
+ 		ret = hostapd_select_hw_mode(iface);
++#ifdef CONFIG_TENDONIN
++		if (ret < 0 && !prescan_done) {
++			prescan_done = 1;
++			hostapd_regulatory_prescan(iface);
++			goto retry_after_prescan;
++		}
++#endif /* CONFIG_TENDONIN */
+ 		if (ret < 0) {
+ 			wpa_printf(MSG_ERROR, "Could not select hw_mode and "
+ 				   "channel. (%d)", ret);
+-- 
+2.55.0
+


### PR DESCRIPTION
# Intel AX200 (iwlwifi / LAR) support: root cause and fix

Barista currently documents Realtek adapters (RTL8852BE, rtw_8821au) as the
tested hardware. This reports a working **Intel Wi-Fi 6 AX200** (`iwlwifi`)
setup, the two distinct root causes that blocked it, and patches for both.
The findings apply to the whole Intel AC/AX family, not just this card.

## Environment

| | |
|---|---|
| Adapter | Intel Wi-Fi 6 AX200 (PCI 8086:2723, rev 1a), `iwlwifi` |
| Firmware | `77.aa2dd297.0` / `cc-a0-77.ucode`, RF HR B3 |
| Kernel | 7.2.4 (CachyOS, Arch-based) |
| OS | CachyOS, KDE Plasma on Wayland |
| GamePad | `8c:cd:e8:4e:01:de` |
| Barista | 0.1.0 at the time of testing |

The AX200 is on the [Vanilla wireless-compatibility list](https://github.com/vanilla-wiiu/vanilla/wiki/Wireless-Compatibility)
as working, but that entry is a ThinkPad X13. **A desktop M.2 card is a
materially different case**: laptops ship ACPI regulatory tables (WRDS/EWRD/
WGDS) that seed the firmware's country, and this board has none — the kernel
log shows no such tables at all. That difference is what makes the problem
below appear.

## Root cause 1 — a self-managed regulatory domain decays to `00`

`iw reg get` reports the phy as **self-managed**:

```
phy#1 (self-managed)
country 00: DFS-UNSET
	(5170 - 5190 @ 160), (6, 22), (N/A), NO-OUTDOOR, AUTO-BW, IR-CONCURRENT, ..., PASSIVE-SCAN
	...
```

Every 5 GHz range carries `IR-CONCURRENT` / `PASSIVE-SCAN` (i.e. no-IR), so
hostapd may not beacon and Barista correctly reports `AP_REGULATORY_BLOCKED`.

Three things are worth stating explicitly, because each is a dead end that
costs time to rediscover:

1. **`iw reg set US` does nothing.** A self-managed phy ignores the kernel
   regulatory core. The global domain shows `country US` while `phy#1` stays
   at `00`. Barista's existing `DRCD_REGULATORY_COUNTRY` override therefore
   cannot help this class of adapter — the log shows it going through the
   motions: `regulatory: preserving existing country US instead of applying
   requested US`, immediately followed by `pairing-channel=no-ir`.
2. **`iwlwifi.lar_disable=1` no longer exists.** It was removed from the
   kernel years ago; the log says `iwlwifi: unknown parameter 'lar_disable'
   ignored`. There is no module option to turn LAR off.
3. **The firmware only learns a country from a scan**, by hearing a Country IE
   from a neighbouring AP — and it decays back to `00` once nothing keeps
   feeding it one. NetworkManager's periodic scans are what normally keep it
   fed, so *releasing the interface for AP mode is what starts the decay.*

**Fix (commit 1):** `RecoverRegulatoryByScan()` drives scans on the target
interface and polls until a pairing channel is usable, wired in as a fallback
in `CheckAdapterWithRegulatoryRecovery()` after the existing country override.
Non-self-managed adapters pass the first capability check and never reach it.

This also repairs a latent gap in that helper: it previously returned failure
immediately when `CanApplyRegulatoryCountry()` was false, so it had no
fallback at all.

## Root cause 2 — hostapd's own AP-mode switch resets the domain

This is the harder half, and the reason fixing only the above is not enough.

With the domain recovered, Barista's checks pass — and hostapd still fails on
**every** candidate channel, DFS and non-DFS alike:

```
adapter-check: wlan0 ... 5ghz=yes pairing-channel=ready
pair-start: channel attempt 1/9 channel=149
hostapd: wlan0: IEEE 802.11 Configured channel (149) or frequency (5745)
         (secondary_channel=0) not found from the channel list of the
         current mode (2) IEEE 802.11a
hostapd: wlan0: IEEE 802.11 Hardware does not support configured channel
```

The check reporting `pairing-channel=ready` and hostapd reporting the channel
missing happened **in the same second**.

Bringing the interface up as an AP is itself a mode change, and LAR resets the
domain on mode change. That happens *inside* hostapd's initialisation — after
any check Barista can perform, and before hostapd reads its channel list.
No amount of verification on Barista's side can close that window.

Evidence that isolates it to hostapd rather than the adapter or the config:
running Barista's own `barista-hostapd` binary by hand, with a config
identical to Barista's generated one (same BSSID, WPS state, vendor elements),
reaches `AP-ENABLED` on channel 36 every time — because NetworkManager was
still managing and scanning the interface, keeping the country alive across
the mode change. The same config under Barista, with the interface released,
fails. MAC-address changes were ruled out separately (pre-setting the pairing
MAC by hand still succeeded).

**Fix (commit 2, hostapd patch 0014):** scan once and retry when
`configured_fixed_chan_to_freq()` or `hostapd_select_hw_mode()` fails, then
re-read the channel list. The scan is reached **only after a failure**, so
adapters that do not self-manage their regulatory domain keep their existing
code path and pay no startup delay. Gated on `CONFIG_TENDONIN`.

## Two prerequisites that are host configuration, not Barista bugs

Both produced confusing, misattributed failures, so they are worth a line in
the troubleshooting docs:

- **rfkill soft-block.** `rfkill list` showing `Soft blocked: yes` surfaces as
  `AP_START_FAILED` ("could not be started"), with the adapter otherwise
  passing every capability check. It recurred twice during testing, so it is
  worth checking first on any regression.
- **Host firewall.** `ufw` default-deny on inbound silently drops the
  GamePad's DHCP and every protocol reply. The symptom is maximally
  misleading: the GamePad associates, the RSN handshake completes,
  `GAMEPAD_ASSOCIATED` fires — and then all `UIC`/`UVC/UAC` commands time out
  while `dhcp: sent OFFER` never appears. A monitor-mode capture showed the
  GamePad's DHCP DISCOVERs arriving and decrypting correctly at -40 dBm,
  proving the radio path was fine and the packets were being dropped locally.

  Note the ports: the log line says `listening on UDP 50010/50022/50023`, but
  `runtime_transport.cpp` binds **six** — 50010, 50020, 50021, 50022, 50023,
  50025. Anyone writing firewall rules from that log line will get it wrong.
  Working rules:

  ```sh
  ufw allow in on wlan0 to any port 67 proto udp
  ufw allow in on wlan0 to any port 50010 proto udp
  ufw allow in on wlan0 to any port 50020:50025 proto udp
  ```

## Result

Pairing, reconnect, and sustained A/V streaming all work. Transport counters
after ~900 frames:

```
Media UDP: video=4485 audio=2631 command=36 uvc_replies=15
           command_retries=4 command_timeouts=0 pad_streaming=active
           errors=0 resync=0
Video encode timing: frames=299 avg_us=964 max_us=1212 over_budget=0
                     idr_frames=0 resync_events=0 coalesced_events=0
```

`resync=0` and `idr_frames=0` after the initial keyframe mean **no GamePad
recovery requests** across the run — better than the baseline the README
describes under *Needs work*. Encode averages ~980 µs against a ~16 ms budget.

Two `runtime-qos` calls fail on this driver and appear to be harmless:

```
runtime-qos: could not enable RTS/CTS for media TID 5: unsupported TID configuration
runtime-qos: could not fix runtime TX rate to HT20 MCS 6: Operation not supported (-95)
```

`iwlwifi` does not implement `set tidconf` or `set bitrates` (`-EOPNOTSUPP`);
the global RTS fallback does apply. Streaming is clean without either, but a
maintainer may want to know these are silently skipped on Intel.

## Dead ends, recorded so nobody repeats them

- `iw reg set <CC>` and `DRCD_REGULATORY_COUNTRY` — ignored by a self-managed
  phy; the global domain changes while the phy stays at `00`.
- `iwlwifi.lar_disable=1` — removed from the kernel years ago, silently
  ignored (`unknown parameter 'lar_disable' ignored`).
- Forcing software crypto / disabling 11ax+11ac — tried on a crypto
  hypothesis that a monitor-mode capture disproved. The final verified
  configuration uses **stock driver settings**.

## Caveats on the patches

- **The 45 s recovery ceiling is a judgement call.** Observed recovery took
  ~3 s in every instance, but the ceiling exceeds the ~20 s pairing-cycle
  cadence, so a worst case lengthens a cycle. Chosen because failing to
  recover is worse than a slow cycle; lower it if you disagree.
- **Recovery depends on a neighbouring 5 GHz AP being in range** to supply a
  Country IE. In true radio isolation there is nothing to learn a country
  from and this approach cannot work. That is a firmware constraint, not
  something the patch can fix.
- **One flaky test.** The first run of the final build had 1/34 fail; it
  passed on three subsequent runs, and the suite is 34/34 on the committed
  tree. I did not capture which test before the output scrolled. It is most
  likely a timing-sensitive `drcd_*` case under parallel build load, and it is
  not exercised by these changes — flagging it rather than omitting it.
- Tested on exactly **one** adapter and one GamePad. The mechanism should hold
  for any self-managed-regulatory driver, but that is reasoning, not evidence.
